### PR TITLE
feature - Final part of the card design

### DIFF
--- a/imports/style.css
+++ b/imports/style.css
@@ -129,6 +129,10 @@ legend{
 	padding: 0 1em;
 }
 /* card */
+.card-image{
+	height: 175px;
+    overflow: hidden;
+}
 .card-body{
 	position: relative;
 }

--- a/imports/ui/partials/Memo.html
+++ b/imports/ui/partials/Memo.html
@@ -1,10 +1,10 @@
 <Template name="Memo">
 		<div class="col l3 m6 s12">
 		 	<div class="card hoverable">
-	            <div class="card-content">
-	            	  <div class="card-image">
-              			<img src="{{thumbnailUrl}}">
+	            	  <div class="card-image valign-wrapper">
+              			<img class="valign" src="{{thumbnailUrl}}">
             		　 </div>
+            		  <div class="card-content">
 		              {{#if isOwner}}
 		              	<i class="fa fa-close"></i>
 		              {{/if}}
@@ -23,9 +23,6 @@
 							{{/if}}
 						  {{/afModal}}
             		  </div>
-	            </div>
-	            <div class="card-action ">
-	              <a href="{{url}}" class="truncate blue-text">{{url}}</a>
 	            </div>
 	        </div>
 		</div>


### PR DESCRIPTION
As the research goes on, we realized that image services such as
imgur, sidebar.io is not using Masonry. This is because Masonry like
UI is hard for user to use in such service. We decided that using
Masonry on this app is not the right approach and tried to use the
card ui on Materialize.
imports/style.css
imports/ui/partials/Memo.html