### PR TITLE
When there's a error on adding memos, spinner does not stop spinning

### DIFF
--- a/imports/ui/partials/NewMemoModal.js
+++ b/imports/ui/partials/NewMemoModal.js
@@ -19,8 +19,8 @@ const hooksObject = {
 	before:{
 		insert:function(doc){
 			let isValidForm = AutoForm.validateForm("NewMemo");
-			Session.set('isLoadingMemo',true);
 			if(isValidForm){
+				Session.set('isLoadingMemo',true);
 				this.resetForm();
 				$('#afModal').closeModal();
 				Meteor.call("addMemo",doc,(err,result)=>{


### PR DESCRIPTION
Also, we should disable the button when adding memos