### PR TITLE
Fix routing

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -31,7 +31,6 @@ materialize:materialize
 gildaspk:autoform-materialize
 themeteorchef:bert
 gildaspk:autoform-modals-materialize
-gwendall:auth-client-callbacks
 dburles:collection-helpers
 lbee:moment-helpers
 percolate:momentum

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -41,7 +41,6 @@ fourseven:scss@3.3.3_3
 geojson-utils@1.0.9
 gildaspk:autoform-materialize@0.0.26
 gildaspk:autoform-modals-materialize@0.0.8
-gwendall:auth-client-callbacks@0.1.0
 hot-code-push@1.0.4
 html-tools@1.0.10
 htmljs@1.0.10

--- a/imports/startup/routes.js
+++ b/imports/startup/routes.js
@@ -17,6 +17,17 @@ Router.configure({
   layoutTemplate: 'MainLayout'
 });
 
+Router.onBeforeAction(function () {
+
+  if (!Meteor.userId()) {
+    Router.go('home');
+  } else {
+    this.next();
+  }
+},{
+	only:['memo.home','memo.detail','memo.board','labeldetail']
+});
+
 Router.route('/home',function(){
 	this.layout('HomeLayout');
 	this.render('Home');
@@ -28,13 +39,6 @@ Router.route('/',function(){
 	this.render('Memos');
 },{
 	name:'memo.home',
-	onBeforeAction:function(){
-		if(!Meteor.user()){
-			Router.go('home');
-		}else{
-			this.next();
-		}
-	}
 });
 
 Router.route('/detail/:_id',function(){
@@ -43,13 +47,6 @@ Router.route('/detail/:_id',function(){
 	});
 },{
 	name:'memo.detail',
-	onBeforeAction:function(){
-		if(!Meteor.user()){
-			Router.go('home');
-		}else{
-			this.next();
-		}
-	}
 });
 
 Router.route('/about',function(){
@@ -62,13 +59,6 @@ Router.route('/board',function(){
 	this.render('Board');
 },{
 	name:'memo.board',
-	onBeforeAction:function(){
-		if(!Meteor.user()){
-			Router.go('home');
-		}else{
-			this.next();
-		}
-	}
 });
 
 Router.route('/label/:labelId', function(){
@@ -81,7 +71,10 @@ Router.route('/label/:labelId', function(){
 //account routing
 //Routes
 AccountsTemplates.configure({
-	defaultLayout:'HomeLayout'
+	defaultLayout:'HomeLayout',
+	onLogoutHook:function(){
+		Router.go('home');
+	},
 });
 AccountsTemplates.configureRoute('enrollAccount');
 AccountsTemplates.configureRoute('resetPwd');

--- a/imports/ui/partials/SideNav.html
+++ b/imports/ui/partials/SideNav.html
@@ -17,7 +17,7 @@
 			      	</li>
 		      	{{else}}
 		      		<li>
-		      			<a href="{{pathFor route='atSignIn'}}" class="waves-effect auth-link">Sign In</a>
+		      			<a href="{{pathFor route='atSignIn'}}" class="waves-effect auth-link">Sign In <i class="fa fa-sign-in"></i></a>
 		      		</li>
 		      	{{/if}}
 		      		<li class="{{isActiveRoute 'about'}}">

--- a/imports/ui/partials/SideNav.js
+++ b/imports/ui/partials/SideNav.js
@@ -5,7 +5,7 @@ import './NewMemoModal.js';
 TemplateController('SideNav',{
 	events:{
 		'click .logout'(){
-			Meteor.logout();
+			AccountsTemplates.logout();
 		},
 	}
 });


### PR DESCRIPTION
Right now, routing is buggy.
## Issues
* When I reload the page, I get redirected to `home`
* Same onBeforeAction methods are used repeatedly, making the code messy
* We are not using https://atmospherejs.com/gwendall/auth-client-callbacks anymore which means users were not redirected to 'home' view after logging out.

## Tasks
- [x] Read Iron Router documentation
- [x] Fix the reloading issue
- [x] Make the onBeforeAction simple
- [x] Redirect the user to 'home' after logging out