### PR TITLE
Overlay does not disappear when resizing

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -41,3 +41,4 @@ reywood:publish-composite
 http
 space:template-controller
 sacha:spin
+gadicohen:reactive-window

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -38,6 +38,7 @@ es5-shim@4.5.12_1
 fastclick@1.0.12
 fortawesome:fontawesome@4.5.0
 fourseven:scss@3.3.3_3
+gadicohen:reactive-window@1.0.6
 geojson-utils@1.0.9
 gildaspk:autoform-materialize@0.0.26
 gildaspk:autoform-modals-materialize@0.0.8
@@ -91,6 +92,7 @@ momentjs:moment@2.10.6
 mongo@1.1.9_1
 mongo-id@1.0.5
 mpowaga:string-template@0.1.0
+mrt:isolate-value@2.0.2
 msavin:jetsetter@2.0.0
 msavin:mongol@2.0.1
 multiply:iron-router-progress@1.0.2

--- a/imports/style.css
+++ b/imports/style.css
@@ -42,7 +42,7 @@ flex: 1 0 auto;
 nav .brand-logo{
 	padding: 0 15px;
 }
-@media (min-width: 991px) {
+@media (min-width: 992px) {
  .app-layout{
     display: none;
   }

--- a/imports/ui/layouts/HomeLayout.js
+++ b/imports/ui/layouts/HomeLayout.js
@@ -10,6 +10,6 @@ import '../partials/Overlay.js';
 
 TemplateController('HomeLayout',{
 	onCreated(){
-		Session.set('shouldHeaderBeShown',false);
+		Session.set('shouldHeaderBeShownAtFullWindow',false);
 	},
 });

--- a/imports/ui/layouts/HomeLayout.js
+++ b/imports/ui/layouts/HomeLayout.js
@@ -10,6 +10,6 @@ import '../partials/Overlay.js';
 
 TemplateController('HomeLayout',{
 	onCreated(){
-		Session.set('Layout',false);
+		Session.set('shouldHeaderBeShown',false);
 	},
 });

--- a/imports/ui/layouts/MainLayout.js
+++ b/imports/ui/layouts/MainLayout.js
@@ -10,6 +10,6 @@ import '../partials/Overlay.js';
 
 TemplateController('MainLayout',{
 	onCreated(){
-		Session.set('shouldHeaderBeShown',true);
+		Session.set('shouldHeaderBeShownAtFullWindow',true);
 	}
 });

--- a/imports/ui/layouts/MainLayout.js
+++ b/imports/ui/layouts/MainLayout.js
@@ -10,6 +10,6 @@ import '../partials/Overlay.js';
 
 TemplateController('MainLayout',{
 	onCreated(){
-		Session.set('Layout',true);
+		Session.set('shouldHeaderBeShown',true);
 	}
 });

--- a/imports/ui/partials/Header.html
+++ b/imports/ui/partials/Header.html
@@ -1,5 +1,5 @@
 <template name="Header">
-  <nav class="{{#if $.Session.get 'Layout'}}app-layout{{/if}}">
+  <nav class="{{#if $.Session.get 'shouldHeaderBeShown'}}app-layout{{/if}}">
     <div class="nav-wrapper blue darken-3">
       <a href="{{pathFor route='memo.home'}}" class="brand-logo">{{title.name}}</a>
       <ul id="nav-mobile" class="right hide-on-med-and-down">
@@ -16,7 +16,7 @@
           <a class="{{isActiveRoute 'about'}}" href="{{pathFor route='about'}}">About</a>
         </li>
       </ul>
-       <ul id="slide-out" class="side-nav  {{#if $.Session.get 'sideNav'}}sidenav-active {{else}} sidenav-inactive {{/if}}">
+       <ul id="slide-out" class="side-nav  {{#if $.Session.get 'isShrinkedSideNavShown'}}sidenav-active {{else}} sidenav-inactive {{/if}}">
           {{#if currentUser}}
             {{> NewMemoModal}}
             <li class="{{isActiveRoute 'memo.home'}}">

--- a/imports/ui/partials/Header.html
+++ b/imports/ui/partials/Header.html
@@ -1,5 +1,5 @@
 <template name="Header">
-  <nav class="{{#if $.Session.get 'shouldHeaderBeShown'}}app-layout{{/if}}">
+  <nav class="{{#if $.Session.get 'shouldHeaderBeShownAtFullWindow'}}app-layout{{/if}}">
     <div class="nav-wrapper blue darken-3">
       <a href="{{pathFor route='memo.home'}}" class="brand-logo">{{title.name}}</a>
       <ul id="nav-mobile" class="right hide-on-med-and-down">

--- a/imports/ui/partials/Header.js
+++ b/imports/ui/partials/Header.js
@@ -10,13 +10,13 @@ TemplateController('Header',{
 
 	events:{
 		'click .toggle-sidenav'(){
-			Session.set('sideNav',!Session.get('sideNav'));
+			Session.set('isShrinkedSideNavShown',!Session.get('isShrinkedSideNavShown'));
 		},
 		'click #slide-out a'(){
-			Session.set('sideNav',false);
+			Session.set('isShrinkedSideNavShown',false);
 		},
-		'click .logout':()=>{
-			Meteor.logout();
+		'click .logout'(){
+			AccountsTemplates.logout();
 		},
 	}
 });

--- a/imports/ui/partials/Overlay.html
+++ b/imports/ui/partials/Overlay.html
@@ -1,4 +1,4 @@
 <template name="Overlay">
-	<div class="overlay {{#if $.Session.get 'sideNav'}}overlay-show{{/if}}">
+	<div class="overlay {{#if shouldOverlayShow }}overlay-show{{/if}}">
 	</div>
 </template>

--- a/imports/ui/partials/Overlay.js
+++ b/imports/ui/partials/Overlay.js
@@ -1,10 +1,19 @@
 import { TemplateController } from 'meteor/space:template-controller';
+import { rwindow } from 'meteor/gadicohen:reactive-window';
 import './Overlay.html';
 
 TemplateController('Overlay',{
+	helpers:{
+		shouldOverlayShow(){
+			if(rwindow.outerWidth() >= 992 && Session.get('isShrinkedSideNavShown') == true){
+				Session.set('isShrinkedSideNavShown',false);
+			}
+			return Session.get('isShrinkedSideNavShown');
+		},
+	},
 	events:{
 		'click .overlay-show'(){
-			Session.set('sideNav',false);
+			Session.set('isShrinkedSideNavShown',false);
 		},
 	},
 });


### PR DESCRIPTION
## Issues

When we resize the window while sidebar is shown, even though the sidebar is gone, overlay is still there
## How to reproduce
1. Shrink the window size
2. Open the sidebar
3. Grow the window size
4. Even though the sidebar is gone, overlay is still there

## Tasks
- [x] Make the overlay disappear when the sidebar is gone