### PR TITLE
Adding memo issue

### DIFF
--- a/imports/style.css
+++ b/imports/style.css
@@ -297,3 +297,8 @@ td{
     background: #333;
     color: #fff;
 }
+/* detail */
+.card-detail-alt-icon{
+	font-size: 10em;
+    color: #999;
+}

--- a/imports/style.css
+++ b/imports/style.css
@@ -180,6 +180,11 @@ legend{
 .card .card-action{
 	padding:10px;
 }
+.card-image-alt-icon{
+	font-size: 8em;
+    margin-top: 15px;
+    color: #999;
+}
 /*board form */
 .new-label{
 	position: relative;

--- a/imports/ui/memoDetail/MemoDetail.html
+++ b/imports/ui/memoDetail/MemoDetail.html
@@ -2,7 +2,11 @@
 	<div class="container about-content">
 		<div class="row">
 			<div class="center">
-				<img class="responsive-img memo-detail-image" src="{{memo.thumbnailUrl}}" alt="{{memo.desc}}">	
+				{{#if memo.thumbnailUrl}}
+					<img class="responsive-img memo-detail-image" src="{{memo.thumbnailUrl}}" alt="{{memo.desc}}">	
+				{{else}}
+					<i class="fa fa-file-text-o card-detail-alt-icon" aria-hidden="true"></i>
+				{{/if}}
 			</div>
 			<div class="col s12">
 				<h5>{{memo.name}}</h5>

--- a/imports/ui/partials/Memo.html
+++ b/imports/ui/partials/Memo.html
@@ -4,30 +4,34 @@
 			{{#if isHovered}}
 		 		<div class="memo-tooltip center truncate">{{url}}</div>
 		 	{{/if}}
-        	  <div class="card-image">
+        	  <div class="card-image center">
+            {{#if thumbnailUrl}}
       			<img class="card-image-url" src="{{thumbnailUrl}}">
+            {{else}}
+              <i class="fa fa-file-text-o card-image-alt-icon" aria-hidden="true"></i>
+            {{/if}}
     		　 </div>
     		  <div class="card-content">
               {{#if isOwner}}
               	<i class="fa fa-close"></i>
               {{/if}}
     		  <div class="card-body">
-	              {{#if desc}}             
-              	  	<p class="truncate">
-				    	{{#if faviconUrl}}
-				    		<img class="favicon" src="{{faviconUrl}}" alt="">
-				    	{{/if}}			 
-              	  		{{name}}
+	            {{#if name}}             
+              	  <p class="truncate">
+    				    	{{#if faviconUrl}}
+    				    		<img class="favicon" src="{{faviconUrl}}" alt="">
+    				    	{{/if}}			 
+              	  {{name}}
               	  	</p>
-              	  {{else}}
-              	  	<p class="grey-text">No descriptions available</p>
-              	  {{/if}}
+              {{else}}
+              	  	<p class="grey-text">No title</p>
+              {{/if}}
               	  <a href="{{pathFor route='memo.detail'}}">more</a>
-              	  {{#if hasLabel}}
+              {{#if hasLabel}}
               	  <a href="{{pathFor route='label.detail'}}" class="btn amber darken-2 edit-btn">
 							{{label.name}}
               	  </a>
-              	  {{/if}}
+              {{/if}}
     		  </div>
             </div>
         </div>


### PR DESCRIPTION
## Issue

<img width="237" alt="2016-11-14 12 31 58" src="https://cloud.githubusercontent.com/assets/15665039/20252526/758268b0-aa66-11e6-89e5-d99982aa74a8.png">

Even though the memo was successfully added with 'name' value, the name is blank for some reason.

## How to reproduce

1. Add memo https://guides.github.com/features/mastering-markdown/
2. Memos with no `thumbnailUrl` shows no image. We should show fontawesome icon as an alternative