### PR TITLE
Delay on showing memo url tooltip

### DIFF
--- a/imports/style.css
+++ b/imports/style.css
@@ -289,13 +289,22 @@ td{
 .memo-tooltip{
 	position: absolute;
     text-align: center;
-    bottom: -22%;
+    bottom: -15%;
     z-index: 2000;
     padding: 6px;
     width: 100%;
     border-radius: 2px;
     background: #333;
     color: #fff;
+    visibility: hidden;
+    opacity: 0;
+    transition:all 0.2s linear;
+}
+.tooltip-show{
+	opacity: 1;
+	bottom:-22%;
+	transition-delay: .5s;
+	visibility: visible;
 }
 /* detail */
 .card-detail-alt-icon{

--- a/imports/ui/partials/Memo.html
+++ b/imports/ui/partials/Memo.html
@@ -1,9 +1,7 @@
 <Template name="Memo">
 	<div class="col l3 m6 s12">
 		<div class="card hoverable">
-			{{#if isHovered}}
-		 		<div class="memo-tooltip center truncate">{{url}}</div>
-		 	{{/if}}
+		 		<div class="memo-tooltip center truncate {{#if isHovered}}tooltip-show{{/if}}">{{url}}</div>
         	  <div class="card-image center">
             {{#if thumbnailUrl}}
       			<img class="card-image-url" src="{{thumbnailUrl}}">


### PR DESCRIPTION
We want some delay before url shows up in hovering memos.

## Suggestions
Use css. Control display:block and display:none
Use Transition.