### PR TITLE
Alt image does not have a link

### DIFF
--- a/imports/style.css
+++ b/imports/style.css
@@ -195,6 +195,7 @@ legend{
 	font-size: 8em;
     margin-top: 15px;
     color: #999;
+    cursor: pointer;
 }
 .card .card-content{
 	padding:7px 12px;

--- a/imports/ui/partials/Memo.js
+++ b/imports/ui/partials/Memo.js
@@ -61,6 +61,10 @@ TemplateController('Memo',{
 			Meteor.call('memoUrlClicked', this.data);
 			window.open(this.data.url);
 		},
+		'click .card-image-alt-icon'(){
+			Meteor.call('memoUrlClicked', this.data);
+			window.open(this.data.url);
+		},
 		'click .fa-share-square'(){
 			window.open(`https://twitter.com/intent/tweet?text=From my memo "${this.data.name}"&url=${this.data.url}`);
 		}


### PR DESCRIPTION
## Issue
Alt image does not have a link to the site. This is a bug.
<img width="233" alt="2016-11-19 14 25 32" src="https://cloud.githubusercontent.com/assets/15665039/20453344/9504a6e2-ae64-11e6-940f-d14f189eba96.png">


Location
- Memo.html
- Memo.js

Tasks
- [x] Make alt image have link