### PR TITLE
Change script on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "WebDevMemo",
   "private": true,
   "scripts": {
-    "start": "meteor run"
+    "start": "meteor --settings settings.json"
   },
   "dependencies": {
     "bootcards": "^1.1.2",


### PR DESCRIPTION
## Overview
Since we are using `settings.json`, we  are starting the meteor by `meteor --settings settings.json`.
In the `package.json`, we can register a short-hand script 
inside it.
Let's add meteor start on this file.

## Tasks
- [x] add `meteor --settings settings.json' as `start` script