### PR TITLE
Fix label sorting problem

### DIFF
--- a/imports/api/label.js
+++ b/imports/api/label.js
@@ -24,8 +24,20 @@ Schemas.label = new SimpleSchema({
 	name:{
 		type:String,
 		label:"name",
-		max:15,
+		max:10,
 	},
+    name_sort: {
+        type: String,
+        optional: true,
+        autoValue: function() {
+            var name = this.field("name");
+            if (name.isSet) {
+                return name.value.toLowerCase();
+            } else {
+                this.unset();
+            }
+        }
+    },
 	color:{
 		type:String,
 		optional:true,

--- a/imports/ui/partials/LabelBar/labelBar.js
+++ b/imports/ui/partials/LabelBar/labelBar.js
@@ -28,10 +28,10 @@ TemplateController('labelBar',{
 			let regex = new RegExp(search,'i');
 			if(search !== ""){
 				this.state.isSearching = true;
-				return Label.find({name:regex}, {sort:{name:1}}).fetch();
+				return Label.find({name:regex}, {sort:{name_sort:1, name:1}}).fetch();
 			}else{
 				this.state.isSearching = false;
-				let projection = {limit:this.state.labelSearchLimit, sort:{name:1}};
+				let projection = {limit:this.state.labelSearchLimit, sort:{name_sort:1, name:1}};
 				this.state.labelResultCount = Label.find({},projection).count();
 				return Label.find({},projection);
 			}

--- a/imports/ui/partials/Modals/AddLabelForm.js
+++ b/imports/ui/partials/Modals/AddLabelForm.js
@@ -20,7 +20,7 @@ TemplateController('AddLabelForm',{
 		],
 	},
 	onRendered(){
-		Session.set('addLabelSelectedColor', "#40c4fff");
+		Session.set('addLabelSelectedColor', "#40c4ff");
 	},
 	helpers:{
 		labelColorsFirst(){
@@ -61,11 +61,9 @@ const hooksObject = {
 		name:insertDoc.name,
 		color:labelColor,
 	};
-	Session.set('isLoadingModal',true);
 	Session.set('showModal',false);
 	Meteor.call('addLabel',labelDoc,(err,result)=>{
 		if(!err){
-			Session.set('isLoadingModal', false);
 			resetModalForm();
 			this.resetForm();
 		}


### PR DESCRIPTION
## Description

Since mongoDB only support sensitive sorting, label's order in label bar is sorted by lower characters, then capital letters which is not intended.
We can solve this by following solution
https://forums.meteor.com/t/how-to-perform-case-insensitive-sorting/1103

## Tasks
- [x]  In `label` api, add `name_sort` field.
- [x]  When adding or editing name, `name_sort` will duplicate the `name` and lowercase them.