### PR TITLE
Add 'show more' button to favorite and recently view row

### DIFF
--- a/imports/stylesheets/pages/feature-page.import.less
+++ b/imports/stylesheets/pages/feature-page.import.less
@@ -1,9 +1,10 @@
 .featured-collection{
 	margin-top: 40px;
 	.collection-item{
+		padding:20px 20px 10px 20px;
 		.title{
 			margin-left: 10px;
-			font-size: 20px;
+			font-size: 24px;
 		}
 	}
 }

--- a/imports/ui/featured/Featured.html
+++ b/imports/ui/featured/Featured.html
@@ -13,6 +13,15 @@
 						{{else}}
 							<span class="grey-text">No favorites!</span>
 						{{/each}}
+						{{#if $gt state.favoriteCount 8}}
+							<div class="col s12 center">
+								{{#if favoriteHasMoreContent}}
+									<button class="btn white black-text show-more-favorite">More</button>
+								{{else}}
+									<button class="btn white black-text hide-favorite">Hide</button>
+								{{/if}}
+							</div>
+						{{/if}}
 					</div>
 				</li>
 				<li class="collection-item">
@@ -23,10 +32,19 @@
 						{{else}}
 							<span class="grey-text">No memos added</span>
 						{{/each}}
+						{{#if $gt state.recentCount 8}}
+							<div class="col s12 center">
+								{{#if recentHasMoreContent}}
+									<button class="btn white black-text show-more-recent">More</button>
+								{{else}}
+									<button class="btn white black-text hide-recent">Hide</button>
+								{{/if}}
+							</div>
+						{{/if}}
 					</div>
 				</li>
 				<li class="collection-item">
-					<span class="title">Recommended
+					<span class="title">For you
 						<span class="chip" style="background-color:{{recommendLabel.color}};">{{recommendLabel.name}}</span>
 					</span>
 					<div class="row">

--- a/imports/ui/featured/Featured.js
+++ b/imports/ui/featured/Featured.js
@@ -11,11 +11,17 @@ const session = new ReactiveDict('Featured');
 
 TemplateController('Featured',{
 	state:{
-		recommendCount:0,
+		recentCount:0,
+		favoriteCount:0,
+	},
+	private:{
+		initialResult:8,
+		incrementBy:8,
 	},
 	onCreated(){
 		this.session = session;
-		this.session.setDefault('resultsLimit', 8);
+		this.session.setDefault('recentResultsLimit',this.initialResult);
+		this.session.setDefault('favoriteResultsLimit',this.initialResult);
 		Session.set('Title',{name:"Featured"});
 		const self = this;
 		self.autorun(()=>{
@@ -37,14 +43,16 @@ TemplateController('Featured',{
 			let query = {
 				isFavorited:true,
 			};
-			return Memos.find(query,{limit:this.session.get('resultsLimit'), sort:{createdAt:-1}});
+			this.state.favoriteCount = Memos.find(query).count();
+			return Memos.find(query,{limit:this.session.get('favoriteResultsLimit'), sort:{createdAt:-1}});
 		},
 		recentMemos(){
 			let query = {
 				status:"active",
 				isFavorited:false,
 			};
-			return Memos.find(query,{limit:this.session.get('resultsLimit'), sort:{clickedAt:-1}});
+			this.state.recentCount = Memos.find(query).count();
+			return Memos.find(query,{limit:this.session.get('recentResultsLimit'), sort:{clickedAt:-1}});
 		},
 		recommendLabel(){
 			if(this.state.recommendCount <= 0){
@@ -63,5 +71,26 @@ TemplateController('Featured',{
 			};
 			return Memos.find(query,{limit:4, sort:{clicked:-1}});
 		},
-	}
+		recentHasMoreContent(){
+			return this.session.get('recentResultsLimit') < this.state.recentCount;
+		},
+		favoriteHasMoreContent(){
+			return this.session.get('favoriteResultsLimit') < this.state.favoriteCount;
+		},
+	},
+
+	events:{
+		'click .show-more-recent'(){
+			this.session.set('recentResultsLimit', this.session.get('recentResultsLimit') + this.incrementBy);
+		},
+		'click .hide-recent'(){
+			this.session.set('recentResultsLimit', this.initialResult);
+		},
+		'click .show-more-favorite'(){
+			this.session.set('favoriteResultsLimit', this.session.get('favoriteResultsLimit') + this.incrementBy);
+		},
+		'click .hide-favorite'(){
+			this.session.set('favoriteResultsLimit', this.initialResult);
+		},
+	},
 });


### PR DESCRIPTION
## Description

Right now, favorite and recently view button show only 8 results which we have more than that.
Let's add a button `show more` that would show more results

## Tasks

- [x] Separate reactive dict variable resultsLimit by row
- [x] Add `Show more` button, try to make them small and flat
- [x] Hide other rows while showing more results
- [x] If needed add infinite scroll