### PR TITLE
Option to remove all memo related to a label

### DIFF
--- a/imports/api/label.js
+++ b/imports/api/label.js
@@ -79,19 +79,24 @@ Meteor.methods({
       username: Meteor.user().username
     });
   },
-  'removeLabel'(id) {
-    check(id, String);
-    const label = Label.findOne(id);
+  'removeLabel'(labelId, shouldDeleteMemo) {
+    check(labelId, String);
+    check(shouldDeleteMemo, Boolean);
+    const label = Label.findOne(labelId);
 
     if (this.userId !== label.owner) {
       throw new Meteor.Error('notAuthorized');
     }
 
-    Label.remove(id);
-    Memos.update({labelId: id},
-      {
-        $unset: {labelId: ""}
-      }, {multi: true});
+    if (shouldDeleteMemo) {
+      Memos.remove({owner: this.userId, labelId: labelId});
+    } else {
+      Memos.update({labelId: labelId},
+        {
+          $unset: {labelId: ""}
+        }, {multi: true});
+    }
+    Label.remove(labelId);
   }
 });
 

--- a/imports/ui/partials/Modals/DeleteLabel.html
+++ b/imports/ui/partials/Modals/DeleteLabel.html
@@ -6,5 +6,11 @@
 			{{label.name}}
 		</span>?
 	</p>
+	{{#if hasAnyMemos}}
+		<p>
+			<input type="checkbox" class="filled-in delete-memo-with-label" id="filled-in-box"/>
+			<label for="filled-in-box">{{i18n 'forms.deleteLabel.deleteMemo'}}</label>
+		</p>
+	{{/if}}
 	<button class="btn red delete-label-btn">{{i18n 'forms.deleteLabel.submit'}}</button>
 </template>

--- a/imports/ui/partials/Modals/DeleteLabel.js
+++ b/imports/ui/partials/Modals/DeleteLabel.js
@@ -1,6 +1,7 @@
 import { TemplateController } from 'meteor/space:template-controller';
 import { resetModalForm } from './modalHelper.js';
 import { Label } from '../../../api/label.js';
+import { Memos } from '../../../api/memos.js';
 import { Meteor } from 'meteor/meteor';
 import { Session } from 'meteor/session';
 
@@ -8,17 +9,21 @@ import './DeleteLabel.html';
 
 TemplateController('DeleteLabel', {
   state: {
+    shouldDeleteMemo: false,
     label: {},
   },
-  onCreated() {
-    const self = this;
-  },
+
   helpers: {
     label() {
       let label = Label.findOne({_id: Session.get('deleteLabelId')});
       this.state.label = label;
       return label;
     },
+    hasAnyMemos() {
+      const labelId = Session.get('deleteLabelId');
+      let memoCount = Memos.find({labelId: labelId}).count();
+      return memoCount > 0;
+    }
   },
 
   events: {
@@ -26,11 +31,15 @@ TemplateController('DeleteLabel', {
       resetModalForm();
     },
     'click .delete-label-btn'() {
-      Meteor.call('removeLabel', this.state.label._id, (err)=>{
+      Meteor.call('removeLabel', this.state.label._id, this.state.shouldDeleteMemo, (err)=>{
         if (!err) {
           resetModalForm();
         }
       });
     },
+    'click .delete-memo-with-label'(event) {
+      let isChecked = event.target.checked;
+      this.state.shouldDeleteMemo = isChecked;
+    }
   }
 });

--- a/imports/ui/partials/ViewOptions.html
+++ b/imports/ui/partials/ViewOptions.html
@@ -9,7 +9,7 @@
 		</div>
 		<div class="col m3 s6">
 		    <p>
-		      <input type="checkbox" class="filled-in" id="filled-in-box" {{isChecked check true}} />
+		      <input type="checkbox" class="filled-in toggle-bookmark-view" id="filled-in-box" {{isChecked check true}} />
 		      <label for="filled-in-box">{{i18n 'gallery.hideExpired'}}</label>
 		    </p>
 		</div>

--- a/imports/ui/partials/ViewOptions.js
+++ b/imports/ui/partials/ViewOptions.js
@@ -17,7 +17,7 @@ TemplateController('ViewOptions', {
     'click .list-view'() {
       Session.set('ListMode', true);
     },
-    'click .filled-in'(event) {
+    'click .toggle-bookmark-view'(event) {
       let isChecked = event.target.checked;
       Session.set('hideExpired', isChecked);
     }

--- a/locale/i18n-client.js
+++ b/locale/i18n-client.js
@@ -133,6 +133,7 @@ i18n.map('en', {
     deleteLabel: {
       title: 'Delete Label',
       messages: 'Are you sure you want to delete',
+      deleteMemo: 'Delete related memos as well',
       submit: 'Delete',
     },
 
@@ -294,6 +295,7 @@ i18n.map('ja', {
     deleteLabel: {
       title: 'ラベル削除',
       messages: 'このラベルを削除してもいいですか',
+      deleteMemo: 'ラベルに関するブックマークも一緒に消去する',
       submit: '削除',
     },
 

--- a/server/publish.js
+++ b/server/publish.js
@@ -12,12 +12,12 @@ Meteor.publish('singleMemo', function(id) {
   return Memos.find({_id: id});
 });
 
-// all user's username
+// All user's username
 Meteor.publish('usernames', function() {
   return Meteor.users.find({}, {fields: {username: 1}});
 });
 
-// all user's favorites
+// All user's favorites
 Meteor.publishComposite('userFavorites', {
   find: function() {
     return userFavorites.find({userId: this.userId});
@@ -82,9 +82,9 @@ Meteor.publishComposite('MemoLabelShares', {
           changed: function(newDocument, oldDocument) {
             self.changed('Label', oldDocument._id, transform(newDocument));
           },
-          removed: function(oldDocument) {
-            self.removed('Label', oldDocument._id);
-          }
+          //removed: function(oldDocument) {
+            //self.removed('Label', oldDocument._id);
+          //}
         });
 
         self.onStop(function() {
@@ -110,14 +110,12 @@ Meteor.publishComposite('MemoLabelShares', {
   ]
 });
 
-// Not used but saved if there's any problem with publish composite
-
-// label publication
+// Label publication
 Meteor.publish('label', function() {
   return Label.find({owner: this.userId});
 });
 
-// Memo publication with query options
+// Memo publication
 Meteor.publish('memos', function() {
   let query    = { owner: this.userId };
   let projection = { limit: 100, sort: { createdAt: -1 } };


### PR DESCRIPTION
## Description
When user is deleting the label. They should have a option to delete all memos that is related to that label.

## Tasks
- [x] Add checkbox on `deleteLabelModal` 
- [x] on `removeLabel` method, add boolean to check if memo should be deleted as well
- [x]  if true, remove memos where owner is user and labelId is the deleted label